### PR TITLE
webhooks controller to display webhook payloads

### DIFF
--- a/changelogger/app/controllers/webhooks_controller.rb
+++ b/changelogger/app/controllers/webhooks_controller.rb
@@ -1,0 +1,10 @@
+class WebhooksController < ApplicationController
+  WEBHOOK_HEADERS = %w(HTTP_USER_AGENT CONTENT_TYPE HTTP_X_GITHUB_EVENT HTTP_X_GITHUB_DELIVERY HTTP_X_HUB_SIGNATURE)
+
+  def create
+    puts JSON.pretty_generate(params.to_unsafe_h)
+    WEBHOOK_HEADERS.each do |header|
+      puts "#{header}: #{request.headers[header]}"
+    end
+  end
+end


### PR DESCRIPTION
Adds controller action that receives the webhook payload and prints the contents and relevant headers to the server logs.

<!--
<changes>
## Step 0: Receive Webhooks

This change allows us to to receive webhook payloads and display them and the relevant headers in the server logs.
</changes>
-->