### PR TITLE
filter events down to the ones we care about

### DIFF
--- a/changelogger/app/controllers/webhooks_controller.rb
+++ b/changelogger/app/controllers/webhooks_controller.rb
@@ -1,10 +1,38 @@
 class WebhooksController < ApplicationController
   WEBHOOK_HEADERS = %w(HTTP_USER_AGENT CONTENT_TYPE HTTP_X_GITHUB_EVENT HTTP_X_GITHUB_DELIVERY HTTP_X_HUB_SIGNATURE)
 
+  before_action :verify_event_type!
+
   def create
+    return unless closed?
+    return unless merged?
+    return unless changelog_enabled?
+
     puts JSON.pretty_generate(params.to_unsafe_h)
     WEBHOOK_HEADERS.each do |header|
       puts "#{header}: #{request.headers[header]}"
+    end
+  end
+
+  private
+
+  def verify_event_type!
+    type = request.headers["HTTP_X_GITHUB_EVENT"]
+    return if type == "pull_request"
+    render(status: 422, json: "unallowed event type: #{type}")
+  end
+
+  def closed?
+    params["webhook"]["action"] == "closed"
+  end
+
+  def merged?
+    !!params["pull_request"]["merged"]
+  end
+
+  def changelog_enabled?
+    params["pull_request"]["labels"].any? do |label|
+      label["name"] == "documentation"
     end
   end
 end


### PR DESCRIPTION
We only care about PRs that have been merged with a specific label, so can filter every other event we receive.

<!--
<changes>
## Step 1: Filter Events

We now drop any event that we receive that isn't a PR being merged with the `documentation` label.
</changes>
-->