### PR TITLE
initialize octokit

### DIFF
--- a/changelogger/app/controllers/webhooks_controller.rb
+++ b/changelogger/app/controllers/webhooks_controller.rb
@@ -4,6 +4,8 @@ class WebhooksController < ApplicationController
   before_action :verify_event_type!
 
   def create
+    puts "octokit user: #{octokit.user}"
+
     return unless closed?
     return unless merged?
     return unless changelog_enabled?
@@ -34,5 +36,9 @@ class WebhooksController < ApplicationController
     params["pull_request"]["labels"].any? do |label|
       label["name"] == "documentation"
     end
+  end
+
+  def octokit
+    @octokit ||= Octokit::Client.new(access_token: Changelogger::Application.credentials.github_personal_access_token)
   end
 end


### PR DESCRIPTION
We need an octokit client to make REST API calls. This initializes a new one with our personal access token and makes a test call to ensure it works.

<!--
<changes>
## Step 2: Octokit

Added an octokit client for making REST API calls.
</changes>
-->