### PR TITLE
use API to create changelog entry

### DIFF
--- a/changelogger/app/controllers/webhooks_controller.rb
+++ b/changelogger/app/controllers/webhooks_controller.rb
@@ -4,16 +4,11 @@ class WebhooksController < ApplicationController
   before_action :verify_event_type!
 
   def create
-    puts "octokit user: #{octokit.user}"
-
     return unless closed?
     return unless merged?
     return unless changelog_enabled?
 
-    puts JSON.pretty_generate(params.to_unsafe_h)
-    WEBHOOK_HEADERS.each do |header|
-      puts "#{header}: #{request.headers[header]}"
-    end
+    create_changelog_entry
   end
 
   private
@@ -40,5 +35,89 @@ class WebhooksController < ApplicationController
 
   def octokit
     @octokit ||= Octokit::Client.new(access_token: Changelogger::Application.credentials.github_personal_access_token)
+  end
+
+  def repo
+    params["repository"]["full_name"]
+  end
+
+  def change_description
+    body = params["pull_request"]["body"]
+    if matches = body.match(/<changes>(.*)<\/changes>/)
+      matches.captures.first.strip
+    else
+      params["pull_request"]["title"]
+    end
+  end
+
+  def diff_url
+    params["pull_request"]["diff_url"]
+  end
+
+  def pr_url
+    params["pull_request"]["html_url"]
+  end
+
+  def author_name
+    params["pull_request"]["user"]["login"]
+  end
+
+  def author_url
+    params["pull_request"]["user"]["html_url"]
+  end
+
+  def author_avatar
+    params["pull_request"]["user"]["avatar_url"]
+  end
+
+  def format_changes
+    <<-ENTRY
+# #{Time.now.utc.to_s}
+
+By: ![avatar](#{author_avatar}&s=50) [#{author_name}](#{author_url})
+
+#{change_description}
+
+[[diff](#{diff_url})][[pull request](#{pr_url})]
+* * *
+
+    ENTRY
+  end
+
+  def default_frontmatter
+    <<-FRONTMATTER
+---
+layout: default
+title: Home
+nav_order: 1
+description: "The Changelog"
+permalink: /
+---
+
+    FRONTMATTER
+  end
+
+  def get_file(repo)
+    response = octokit.contents(repo, path: "docs/index.md")
+    [Base64.decode64(response["content"]), response["sha"]]
+  rescue
+    nil
+  end
+
+  def create_changelog_entry
+    content, sha = get_file(repo)
+
+    if content
+      octokit.update_contents(repo,
+                                 "docs/index.md",
+                                 "New changelog entry",
+                                 sha,
+                                 content + format_changes)
+    else
+      octokit.create_contents(repo,
+                                 "docs/index.md",
+                                 "New changelog entry",
+                                 default_frontmatter + format_changes)
+    end
   end
 end


### PR DESCRIPTION
Adds logic to check for the `docs/index.md`. When it exists, it appends a new changelog entry. When it doesn't, creates the file with the default front matter and new entry.

<!--
<changes>
## Step 3: Create Changelog Entries

Now we can add new entries to a `doc/index.md`. If one doesn't exist already, we create one with default frontmatter and the new entry.
</changes>
-->