### PR TITLE
Workshop.md updates

### DIFF
--- a/workshop.md
+++ b/workshop.md
@@ -16,7 +16,7 @@ To get started you first need to fork this repository
 
 <img src="https://user-images.githubusercontent.com/3330181/80671986-5fbb2e80-8a79-11ea-8c4f-aa12514ea4bc.png" width=1000>
 
-clone your fork to your local machine
+clone your forked repo to your local machine
 
 <img src="https://user-images.githubusercontent.com/3330181/80672075-a1e47000-8a79-11ea-82d7-544c323642b2.png" width=500>
 
@@ -25,7 +25,7 @@ git clone git@github.com:<username>/webhooks-with-rest.git --config core.autocrl
 ```
 
 
-## Docker
+## Bootstrap
 
 Now that you have the repo locally `cd` into that directory and run
 
@@ -49,22 +49,22 @@ Now that you have the docker image created, we need to setup some credentials.
 
 ### Personal acess token
 
-Let's generate a personal access token (PAT) for this workshop. First head to https://github.com/settings/tokens/new. Once there, name your token and select the following scopes at a minimum:
-- `repo`
-- `admin:hook`
+Let's generate a personal access token (PAT) for this workshop. First head to https://github.com/settings/tokens/new. Once there, name your token and select the `repo` scope.
 
 <details>
   <summary>Example Configuration</summary>
 
-![image](https://user-images.githubusercontent.com/3330181/80562163-e528db00-89b4-11ea-92a1-3f7143d5da50.png)
+![image](https://user-images.githubusercontent.com/3330181/81121364-8c999680-8efc-11ea-8a07-77cec8cc5973.png)
 
 </details>
 
-Once you've generated it, be sure to copy it because you won't be able to view it again. With it copied to your clipboard, open a file called `/changelogger/.env` on your favourite editor and update the value of the environment variable `GITHUB_PERSONAL_ACCESS_TOKEN` to the one that you just copied
+Once you've generated it, be sure to copy it because you won't be able to view it again. 
+
+With it copied to your clipboard, open a file called `/changelogger/.env` on your favorite editor and update the value of the environment variable `GITHUB_PERSONAL_ACCESS_TOKEN` to the one that you just copied.
 
 ### Webhook secret
 
-When we configure our webhook in a few minutes, we are going to do so with a random secret token. In general, it's best to use a very random string, but for today just pick anything that you can remember for long enough to configure your webhook with. Then follow exactly what we did for the personal access token but this time update the value of the environment variable `GITHUB_WEBHOOK_SECRET` to the one that you just copied
+When we configure our webhook in a few minutes, we are going to do so with a random secret token. In general, it's best to use a very random string, but for today just pick anything that you can remember for long enough to configure your webhook with. Then follow exactly what we did for the personal access token but this time update the value of the environment variable `GITHUB_WEBHOOK_SECRET` to the one that you just copied.
 
 ## Enable GitHub Pages
 
@@ -145,7 +145,7 @@ Which will bring you to the form for creating a new repository webhook.
 
 You will need a webhook with the following configuration:
 
-- URL: paste your ngrok generated URL into the URL field with `/webhooks` appended to the end (e.g. `http://044af013.ngrok.io/webhooks`)
+- URL: paste your ngrok generated URL into the URL field
 - Content Type: select json
 - Secret: use the secret that you added as part of your credentials
 - Events: select only the `Pull Requests` events
@@ -154,7 +154,7 @@ You will need a webhook with the following configuration:
 <details>
   <summary>Example Configuration</summary>
 
-![image](https://user-images.githubusercontent.com/3330181/80561790-a21a3800-89b3-11ea-8c27-445685c73559.png)
+![image](https://user-images.githubusercontent.com/3330181/81121611-25c8ad00-8efd-11ea-9658-cdec1607dbf2.png)
 
 </details>
 
@@ -163,7 +163,7 @@ Once you add the event, you should see a ping event in both the logs
 <details>
   <summary>Delivery Logs</summary>
 
-![image](https://user-images.githubusercontent.com/3330181/80561855-d857b780-89b3-11ea-95e7-dd59808a315c.png)
+![image](https://user-images.githubusercontent.com/3330181/81121703-5ad4ff80-8efd-11ea-842a-0fb43306b9d8.png)
 
 </details>
 
@@ -174,11 +174,11 @@ and in the server output
 
 ```
 {
-  "zen": "Design for failure.",
-  "hook_id": 206101205,
+  "zen": "Keep it logically awesome.",
+  "hook_id": 208294689,
   "hook": {
     "type": "Repository",
-    "id": 206101205,
+    "id": 208294689,
     "name": "web",
     "active": true,
     "events": [
@@ -188,13 +188,13 @@ and in the server output
       "content_type": "json",
       "insecure_ssl": "0",
       "secret": "********",
-      "url": "http://044af013.ngrok.io/webhooks"
+      "url": "http://738493f3.ngrok.io"
     },
-    "updated_at": "2020-04-29T04:51:24Z",
-    "created_at": "2020-04-29T04:51:24Z",
-    "url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/206101205",
-    "test_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/206101205/test",
-    "ping_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/206101205/pings",
+    "updated_at": "2020-05-05T22:21:09Z",
+    "created_at": "2020-05-05T22:21:09Z",
+    "url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/208294689",
+    "test_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/208294689/test",
+    "ping_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/208294689/pings",
     "last_response": {
       "code": null,
       "status": "unused",
@@ -206,7 +206,7 @@ and in the server output
     "node_id": "MDEwOlJlcG9zaXRvcnkyNTg1ODQ0NjM=",
     "name": "webhooks-with-rest",
     "full_name": "githubsatelliteworkshops/webhooks-with-rest",
-    "private": true,
+    "private": false,
     "owner": {
       "login": "githubsatelliteworkshops",
       "id": 64148422,
@@ -268,30 +268,30 @@ and in the server output
     "releases_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/releases{/id}",
     "deployments_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/deployments",
     "created_at": "2020-04-24T17:55:13Z",
-    "updated_at": "2020-04-28T17:52:29Z",
-    "pushed_at": "2020-04-28T17:52:27Z",
+    "updated_at": "2020-05-05T22:08:56Z",
+    "pushed_at": "2020-05-05T22:10:16Z",
     "git_url": "git://github.com/githubsatelliteworkshops/webhooks-with-rest.git",
     "ssh_url": "git@github.com:githubsatelliteworkshops/webhooks-with-rest.git",
     "clone_url": "https://github.com/githubsatelliteworkshops/webhooks-with-rest.git",
     "svn_url": "https://github.com/githubsatelliteworkshops/webhooks-with-rest",
     "homepage": "",
-    "size": 17,
+    "size": 27401,
     "stargazers_count": 0,
     "watchers_count": 0,
-    "language": null,
+    "language": "Ruby",
     "has_issues": true,
     "has_projects": false,
     "has_downloads": true,
     "has_wiki": false,
-    "has_pages": false,
-    "forks_count": 0,
+    "has_pages": true,
+    "forks_count": 2,
     "mirror_url": null,
     "archived": false,
     "disabled": false,
-    "open_issues_count": 0,
+    "open_issues_count": 1,
     "license": null,
-    "forks": 0,
-    "open_issues": 0,
+    "forks": 2,
+    "open_issues": 1,
     "watchers": 0,
     "default_branch": "master"
   },
@@ -314,159 +314,14 @@ and in the server output
     "received_events_url": "https://api.github.com/users/janester/received_events",
     "type": "User",
     "site_admin": true
-  },
-  "controller": "webhooks",
-  "action": "create",
-  "webhook": {
-    "zen": "Design for failure.",
-    "hook_id": 206101205,
-    "hook": {
-      "type": "Repository",
-      "id": 206101205,
-      "name": "web",
-      "active": true,
-      "events": [
-        "pull_request"
-      ],
-      "config": {
-        "content_type": "json",
-        "insecure_ssl": "0",
-        "secret": "********",
-        "url": "http://044af013.ngrok.io/webhooks"
-      },
-      "updated_at": "2020-04-29T04:51:24Z",
-      "created_at": "2020-04-29T04:51:24Z",
-      "url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/206101205",
-      "test_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/206101205/test",
-      "ping_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks/206101205/pings",
-      "last_response": {
-        "code": null,
-        "status": "unused",
-        "message": null
-      }
-    },
-    "repository": {
-      "id": 258584463,
-      "node_id": "MDEwOlJlcG9zaXRvcnkyNTg1ODQ0NjM=",
-      "name": "webhooks-with-rest",
-      "full_name": "githubsatelliteworkshops/webhooks-with-rest",
-      "private": true,
-      "owner": {
-        "login": "githubsatelliteworkshops",
-        "id": 64148422,
-        "node_id": "MDEyOk9yZ2FuaXphdGlvbjY0MTQ4NDIy",
-        "avatar_url": "https://avatars1.githubusercontent.com/u/64148422?v=4",
-        "gravatar_id": "",
-        "url": "https://api.github.com/users/githubsatelliteworkshops",
-        "html_url": "https://github.com/githubsatelliteworkshops",
-        "followers_url": "https://api.github.com/users/githubsatelliteworkshops/followers",
-        "following_url": "https://api.github.com/users/githubsatelliteworkshops/following{/other_user}",
-        "gists_url": "https://api.github.com/users/githubsatelliteworkshops/gists{/gist_id}",
-        "starred_url": "https://api.github.com/users/githubsatelliteworkshops/starred{/owner}{/repo}",
-        "subscriptions_url": "https://api.github.com/users/githubsatelliteworkshops/subscriptions",
-        "organizations_url": "https://api.github.com/users/githubsatelliteworkshops/orgs",
-        "repos_url": "https://api.github.com/users/githubsatelliteworkshops/repos",
-        "events_url": "https://api.github.com/users/githubsatelliteworkshops/events{/privacy}",
-        "received_events_url": "https://api.github.com/users/githubsatelliteworkshops/received_events",
-        "type": "Organization",
-        "site_admin": false
-      },
-      "html_url": "https://github.com/githubsatelliteworkshops/webhooks-with-rest",
-      "description": "Building GitHub integrations with webhooks and REST",
-      "fork": false,
-      "url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest",
-      "forks_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/forks",
-      "keys_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/keys{/key_id}",
-      "collaborators_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/collaborators{/collaborator}",
-      "teams_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/teams",
-      "hooks_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/hooks",
-      "issue_events_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/issues/events{/number}",
-      "events_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/events",
-      "assignees_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/assignees{/user}",
-      "branches_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/branches{/branch}",
-      "tags_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/tags",
-      "blobs_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/git/blobs{/sha}",
-      "git_tags_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/git/tags{/sha}",
-      "git_refs_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/git/refs{/sha}",
-      "trees_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/git/trees{/sha}",
-      "statuses_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/statuses/{sha}",
-      "languages_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/languages",
-      "stargazers_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/stargazers",
-      "contributors_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/contributors",
-      "subscribers_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/subscribers",
-      "subscription_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/subscription",
-      "commits_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/commits{/sha}",
-      "git_commits_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/git/commits{/sha}",
-      "comments_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/comments{/number}",
-      "issue_comment_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/issues/comments{/number}",
-      "contents_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/contents/{+path}",
-      "compare_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/compare/{base}...{head}",
-      "merges_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/merges",
-      "archive_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/{archive_format}{/ref}",
-      "downloads_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/downloads",
-      "issues_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/issues{/number}",
-      "pulls_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/pulls{/number}",
-      "milestones_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/milestones{/number}",
-      "notifications_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/notifications{?since,all,participating}",
-      "labels_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/labels{/name}",
-      "releases_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/releases{/id}",
-      "deployments_url": "https://api.github.com/repos/githubsatelliteworkshops/webhooks-with-rest/deployments",
-      "created_at": "2020-04-24T17:55:13Z",
-      "updated_at": "2020-04-28T17:52:29Z",
-      "pushed_at": "2020-04-28T17:52:27Z",
-      "git_url": "git://github.com/githubsatelliteworkshops/webhooks-with-rest.git",
-      "ssh_url": "git@github.com:githubsatelliteworkshops/webhooks-with-rest.git",
-      "clone_url": "https://github.com/githubsatelliteworkshops/webhooks-with-rest.git",
-      "svn_url": "https://github.com/githubsatelliteworkshops/webhooks-with-rest",
-      "homepage": "",
-      "size": 17,
-      "stargazers_count": 0,
-      "watchers_count": 0,
-      "language": null,
-      "has_issues": true,
-      "has_projects": false,
-      "has_downloads": true,
-      "has_wiki": false,
-      "has_pages": false,
-      "forks_count": 0,
-      "mirror_url": null,
-      "archived": false,
-      "disabled": false,
-      "open_issues_count": 0,
-      "license": null,
-      "forks": 0,
-      "open_issues": 0,
-      "watchers": 0,
-      "default_branch": "master"
-    },
-    "sender": {
-      "login": "janester",
-      "id": 3330181,
-      "node_id": "MDQ6VXNlcjMzMzAxODE=",
-      "avatar_url": "https://avatars1.githubusercontent.com/u/3330181?v=4",
-      "gravatar_id": "",
-      "url": "https://api.github.com/users/janester",
-      "html_url": "https://github.com/janester",
-      "followers_url": "https://api.github.com/users/janester/followers",
-      "following_url": "https://api.github.com/users/janester/following{/other_user}",
-      "gists_url": "https://api.github.com/users/janester/gists{/gist_id}",
-      "starred_url": "https://api.github.com/users/janester/starred{/owner}{/repo}",
-      "subscriptions_url": "https://api.github.com/users/janester/subscriptions",
-      "organizations_url": "https://api.github.com/users/janester/orgs",
-      "repos_url": "https://api.github.com/users/janester/repos",
-      "events_url": "https://api.github.com/users/janester/events{/privacy}",
-      "received_events_url": "https://api.github.com/users/janester/received_events",
-      "type": "User",
-      "site_admin": true
-    }
   }
 }
-HTTP_USER_AGENT: GitHub-Hookshot/c2aec4a
+HTTP_USER_AGENT: GitHub-Hookshot/7431eee
 CONTENT_TYPE: application/json
 HTTP_X_GITHUB_EVENT: ping
-HTTP_X_GITHUB_DELIVERY: 13b6ae00-89d5-11ea-8a41-7c0c4466380a
-HTTP_X_HUB_SIGNATURE: sha1=1d1ff727024d4dd7040a0c3292debf4b6f506a32
-method=POST path=/webhooks format=*/* controller=WebhooksController action=create status=204 duration=7.02 view=0.00
+HTTP_X_GITHUB_DELIVERY: b82d7880-8f1e-11ea-8f58-aae643ef5b38
+HTTP_X_HUB_SIGNATURE: sha1=8e0edbf5f09e88602898c24430008150a1934fdc
+method=POST path=/ format=*/* controller=WebhooksController action=create status=204 duration=5.26 view=0.00
 ```
 
 </details>

--- a/workshop.md
+++ b/workshop.md
@@ -332,9 +332,9 @@ Congrats! You just recieved your first webhook! 🎉
 
 The next step is to filter the events that we recieve to only act upon the ones that we care about. Use the payload's fields to determine which ones we want. For this project we care only about the pull requests that:
 
-- have the special changelog label
 - the action is closed
 - the PR's state is merged and not just closed
+- have the special changelog label
 
 We'll work on adding this code together, but if you fall behind, feel free to check out the `filter-events` branch, which has this step complete already.
 


### PR DESCRIPTION
We had some outdated info on here, so I updated it.

- PAT only needs repo scope
- Don't configure hook with `/webhooks`
- updated images for all

Rendered: https://github.com/githubsatelliteworkshops/webhooks-with-rest/blob/2b09c1aab0a00ab15d7136fcc91c553c7905a8c0/workshop.md